### PR TITLE
Added table transactions and improve cell editing behavior

### DIFF
--- a/.changeset/fluffy-places-shave.md
+++ b/.changeset/fluffy-places-shave.md
@@ -1,0 +1,5 @@
+---
+'@timlassiter11/yatl': patch
+---
+
+Disable cell editing while they are involved in a pending transaction

--- a/.changeset/lucky-beans-remain.md
+++ b/.changeset/lucky-beans-remain.md
@@ -1,0 +1,5 @@
+---
+'@timlassiter11/yatl': patch
+---
+
+Added new editTrigger property to the table for controlling how a user initiates cell editing

--- a/.changeset/soft-kings-lead.md
+++ b/.changeset/soft-kings-lead.md
@@ -1,0 +1,5 @@
+---
+'@timlassiter11/yatl': patch
+---
+
+Added new respondWith callback to table commit request events for automatically closing the request based on the return

--- a/.changeset/strong-books-create.md
+++ b/.changeset/strong-books-create.md
@@ -1,0 +1,5 @@
+---
+'@timlassiter11/yatl': patch
+---
+
+Added transaction API to controller and cell edit states to table UI

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -150,12 +150,7 @@ function initTable() {
       field: 'status',
       title: 'Status',
       searchable: false,
-      editor: new SelectEditor<TableData>({
-        onSave: (oldValue, newValue, field, row) => {
-          row.lastModified = new Date();
-          return newValue;
-        },
-      }),
+      editor: new SelectEditor<TableData>(),
     },
     {
       field: 'lastModified',

--- a/packages/yatl/src/editors/base.ts
+++ b/packages/yatl/src/editors/base.ts
@@ -1,31 +1,14 @@
 import { YatlTableController } from '../table-controller/table-controller';
-import {
-  CellEditor,
-  MaybePromise,
-  NestedKeyOf,
-  UnspecifiedRecord,
-} from '../types';
+import { CellEditor, NestedKeyOf, UnspecifiedRecord } from '../types';
 
 export interface BaseEditorOptions<T extends object = UnspecifiedRecord> {
   canEdit?: (field: NestedKeyOf<T>, row: T) => boolean;
-  onSave?: (
-    oldValue: unknown,
-    newValue: unknown,
-    field: NestedKeyOf<T>,
-    row: T,
-  ) => MaybePromise<unknown | undefined>;
 }
 
 export abstract class BaseEditor<T extends object = UnspecifiedRecord>
   implements CellEditor<T>
 {
-  protected currentValue: unknown;
-
   constructor(protected readonly options?: BaseEditorOptions<T>) {}
-
-  public reset() {
-    this.currentValue = undefined;
-  }
 
   public canEdit(field: NestedKeyOf<T>, row: T) {
     return this.options?.canEdit?.(field, row) ?? true;
@@ -37,24 +20,4 @@ export abstract class BaseEditor<T extends object = UnspecifiedRecord>
     row: T,
     controller: YatlTableController<T>,
   ): unknown;
-
-  public save(
-    originalValue: unknown,
-    field: NestedKeyOf<T>,
-    row: T,
-    _controller: YatlTableController<T>,
-  ) {
-    if (
-      this.currentValue === undefined ||
-      this.currentValue === originalValue
-    ) {
-      return;
-    }
-
-    if (!this.options?.onSave) {
-      return this.currentValue;
-    }
-
-    return this.options.onSave(originalValue, this.currentValue, field, row);
-  }
 }

--- a/packages/yatl/src/editors/index.ts
+++ b/packages/yatl/src/editors/index.ts
@@ -1,3 +1,4 @@
+export * from './date-editor';
 export * from './input-editor';
 export * from './number-editor';
 export * from './select-editor';

--- a/packages/yatl/src/editors/input-editor.ts
+++ b/packages/yatl/src/editors/input-editor.ts
@@ -1,6 +1,5 @@
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { live } from 'lit/directives/live.js';
 import { YatlTableController } from '../table-controller/table-controller';
 import { NestedKeyOf, UnspecifiedRecord } from '../types';
 import { BaseEditor, BaseEditorOptions } from './base';
@@ -14,13 +13,44 @@ export class InputEditor<
 
   public render(
     value: unknown,
-    _field: NestedKeyOf<T>,
-    _row: T,
-    _controller: YatlTableController<T>,
+    field: NestedKeyOf<T>,
+    row: T,
+    controller: YatlTableController<T>,
   ) {
+    const save = (event: Event) => {
+      const target = event.target as HTMLInputElement;
+      const { type, max, min } = this.options ?? {};
+
+      let newValue;
+      if (type === 'checkbox') {
+        newValue = target.checked;
+      } else if (type === 'date' || type === 'datetime-local') {
+        newValue = target.valueAsDate;
+      } else if (type === 'number') {
+        newValue = target.valueAsNumber;
+        if (isNaN(newValue)) {
+          newValue = null;
+        } else {
+          if (typeof max === 'number' && newValue > max) {
+            target.valueAsNumber = max;
+            newValue = max;
+          } else if (typeof min === 'number' && newValue < min) {
+            target.valueAsNumber = min;
+            newValue = min;
+          }
+        }
+      } else {
+        newValue = target.value;
+      }
+
+      if (newValue !== undefined) {
+        controller.setPendingValue(row, field, newValue);
+      }
+    };
+
     return html`
       <input
-        .value=${live(String(value ?? ''))}
+        value=${String(value ?? '')}
         type=${ifDefined(this.options?.type)}
         minlength=${ifDefined(this.options?.minlength)}
         maxlength=${ifDefined(this.options?.maxlength)}
@@ -30,37 +60,10 @@ export class InputEditor<
         pattern=${ifDefined(this.options?.pattern)}
         placeholder=${ifDefined(this.options?.placeholder)}
         autofocus
-        @input=${this.handleChange}
+        @input=${save}
       />
     `;
   }
-
-  private handleChange = (event: Event) => {
-    const target = event.target as HTMLInputElement;
-    const { type, max, min } = this.options ?? {};
-
-    if (type === 'checkbox') {
-      this.currentValue = target.checked;
-    } else if (type === 'date' || type === 'datetime-local') {
-      this.currentValue = target.valueAsDate;
-    } else if (type === 'number') {
-      let value: number | null = target.valueAsNumber;
-      if (isNaN(value)) {
-        value = null;
-      } else {
-        if (typeof max === 'number' && value > max) {
-          target.valueAsNumber = max;
-          value = max;
-        } else if (typeof min === 'number' && value < min) {
-          target.valueAsNumber = min;
-          value = min;
-        }
-        this.currentValue = value;
-      }
-    } else {
-      this.currentValue = target.value;
-    }
-  };
 }
 
 export type InputType =

--- a/packages/yatl/src/editors/select-editor.ts
+++ b/packages/yatl/src/editors/select-editor.ts
@@ -1,9 +1,9 @@
-import { html } from 'lit';
-import { live } from 'lit/directives/live.js';
+import { html, TemplateResult } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { YatlTableController } from '../table-controller/table-controller';
 import { NestedKeyOf, UnspecifiedRecord } from '../types';
 import { BaseEditor, BaseEditorOptions } from './base';
+import { isTemplateResult } from 'lit/directive-helpers.js';
 
 export class SelectEditor<
   T extends object = UnspecifiedRecord,
@@ -18,19 +18,36 @@ export class SelectEditor<
     row: T,
     controller: YatlTableController<T>,
   ) {
-    const values = controller.getColumnFilterValues(field, false);
+    const save = (event: Event) => {
+      const target = event.target as HTMLSelectElement;
+      controller.setPendingValue(row, field, target.value);
+    };
+
     return html`
-      <select .value=${live(String(value))} @change=${this.handleChange}>
-        ${repeat(
-          values.keys(),
-          option => option,
-          option => this.renderOption(option, option === value),
-        )}
+      <select value=${String(value)} @change=${save}>
+        ${this.renderOptions(value, field, controller)}
       </select>
     `;
   }
 
-  public renderOption(option: unknown, select: boolean) {
+  protected renderOptions(
+    value: unknown,
+    field: NestedKeyOf<T>,
+    controller: YatlTableController<T>,
+  ) {
+    if (isTemplateResult(this.options?.options)) {
+      return this.options?.options;
+    }
+
+    const values = controller.getColumnFilterValues(field, false);
+    return repeat(
+      values.keys(),
+      option => option,
+      option => this.renderOption(option, option === value),
+    );
+  }
+
+  protected renderOption(option: unknown, select: boolean) {
     const [value, display] = this.options?.labelRenderer?.(option) ?? [
       String(option),
       String(option),
@@ -39,14 +56,10 @@ export class SelectEditor<
       <option value=${value} ?selected=${select}>${display}</option>
     `;
   }
-
-  private handleChange = (event: Event) => {
-    const target = event.target as HTMLSelectElement;
-    this.currentValue = target.value;
-  };
 }
 
 export interface SelectEditorOptions<T extends object = UnspecifiedRecord>
   extends BaseEditorOptions<T> {
+  options?: [string, string][] | TemplateResult;
   labelRenderer?: (value: unknown) => [string, string];
 }

--- a/packages/yatl/src/events.ts
+++ b/packages/yatl/src/events.ts
@@ -1,4 +1,5 @@
 import {
+  MaybePromise,
   NestedKeyOf,
   RowId,
   SortOrder,
@@ -170,7 +171,10 @@ export class YatlTableCommitRequest<
 > extends YatlEvent {
   public static readonly EVENT_NAME = 'yatl-table-commit-request';
 
-  constructor(public readonly transaction: YatlCommitTransaction<T>) {
+  constructor(
+    public readonly transaction: YatlCommitTransaction<T>,
+    public readonly respondWith: (promise: MaybePromise<boolean>) => void,
+  ) {
     super(YatlTableCommitRequest.EVENT_NAME);
   }
 }

--- a/packages/yatl/src/events.ts
+++ b/packages/yatl/src/events.ts
@@ -4,6 +4,7 @@ import {
   SortOrder,
   TableState,
   UnspecifiedRecord,
+  YatlCommitTransaction,
 } from './types';
 
 /**
@@ -164,19 +165,13 @@ export class YatlColumnReorderEvent<
   }
 }
 
-export class YatlCellEditEvent<
+export class YatlTableCommitRequest<
   T extends object = UnspecifiedRecord,
 > extends YatlEvent {
-  public static readonly EVENT_NAME = 'yatl-cell-edit';
+  public static readonly EVENT_NAME = 'yatl-table-commit-request';
 
-  constructor(
-    public readonly row: T,
-    public readonly rowId: RowId,
-    public readonly field: NestedKeyOf<T>,
-    public readonly originalValue: unknown,
-    public readonly currentValue: unknown,
-  ) {
-    super(YatlCellEditEvent.EVENT_NAME);
+  constructor(public readonly transaction: YatlCommitTransaction<T>) {
+    super(YatlTableCommitRequest.EVENT_NAME);
   }
 }
 

--- a/packages/yatl/src/table-controller/table-controller.ts
+++ b/packages/yatl/src/table-controller/table-controller.ts
@@ -811,6 +811,17 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
     return 'clean';
   }
 
+  public isCellEditable(row: T | RowId, field: NestedKeyOf<T>) {
+    row = this.getRowOrThrow(row);
+    const col = this.getDisplayColumn(field);
+    if (!col || !col.editor || !col.editor.canEdit(field, row)) {
+      return false;
+    }
+
+    const metadata = this.getRowMetadata(row);
+    return !metadata.pendingTransactions.has(field);
+  }
+
   public getPendingChanges() {
     return this.getTransactionRecords();
   }

--- a/packages/yatl/src/table-controller/table-controller.ts
+++ b/packages/yatl/src/table-controller/table-controller.ts
@@ -121,8 +121,10 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
   private filterDirty = false;
   private sortDirty = false;
 
-  // Maps rows to their metadata
-  private rowMetadata = new WeakMap<T, RowMetadata>();
+  // Maps rows ids to their metadata
+  private rowMetadata = new Map<RowId, RowMetadata>();
+  // Maps row objects to their generated IDs
+  private rowToIdMap = new WeakMap<T, RowId>();
   // Map row ids to their rows for faster lookup
   private idToRowMap = new Map<RowId, T>();
   // List of tokens created from the current query
@@ -148,7 +150,7 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
     for (const column of columns) {
       this._columnDefinitionMap.set(column.field, column);
     }
-    this.createMetadata();
+    this.rebuildMetadata();
     this.requestUpdate('columns');
   }
 
@@ -197,7 +199,7 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
     }
 
     this._data = [...data];
-    this.createMetadata();
+    this.rebuildMetadata();
     this._dataUpdateTimestamp = new Date();
     this.filterDirty = true;
     this.requestUpdate('data');
@@ -340,12 +342,19 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
       return;
     }
 
-    this._rowIdCallback = callback;
     // Update IDs in metadata for existing data.
     for (let i = 0; i < this.data.length; ++i) {
       const row = this.data[i];
-      this.rowMetadata.get(row)!.id = this._rowIdCallback(row, i);
+      const oldId = this._rowIdCallback(row, i);
+      const newId = callback(row, i);
+
+      const metadata = this.rowMetadata.get(oldId);
+      this.rowMetadata.delete(oldId);
+      if (metadata) {
+        this.rowMetadata.set(newId, metadata);
+      }
     }
+    this._rowIdCallback = callback;
     this.requestUpdate('rowIdCallback');
   }
 
@@ -797,7 +806,7 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
   }
 
   public getCellStatus(row: T | RowId, field: NestedKeyOf<T>) {
-    const metadata = this.rowMetadata.get(this.getRowOrThrow(row));
+    const metadata = this.getRowMetadata(row);
     if (!metadata) return 'clean';
 
     if (metadata.pendingTransactions.has(field as string)) {
@@ -920,7 +929,7 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
   public findRowIndex(field: NestedKeyOf<T>, value: unknown) {
     const row = this.findRow(field, value);
     if (row) {
-      return this.rowMetadata.get(row)!.index;
+      return this.getRowMetadata(row).index;
     }
     return -1;
   }
@@ -958,10 +967,11 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
    */
   public deleteRow(...rowIds: RowId[]) {
     for (const rowId of rowIds) {
-      const row = this.idToRowMap.get(rowId);
-      if (row) {
-        const metadata = this.rowMetadata.get(row)!;
+      try {
+        const metadata = this.getRowMetadata(rowId);
         this.deleteRowAtIndex(metadata.index);
+      } catch {
+        // We don't care if they try to delete a row that doesn't actually exist.
       }
     }
   }
@@ -975,9 +985,10 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
     for (const index of indexes) {
       const row = this.data[index];
       if (row) {
-        const metadata = this.rowMetadata.get(row)!;
+        const metadata = this.getRowMetadata(row);
         this.idToRowMap.delete(metadata.id);
-        this.rowMetadata.delete(row);
+        this.rowMetadata.delete(metadata.id);
+        this.editedRows.delete(metadata.id);
         newSelectedRows.delete(metadata.id);
         this.data = this.data.toSpliced(index, 1);
       }
@@ -986,27 +997,22 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
   }
 
   public getRowId(row: T) {
-    const metadata = this.rowMetadata.get(row);
-    if (!metadata) {
-      throw new Error('The provided row does not exist in the current dataset');
+    const id = this.rowToIdMap.get(row);
+    if (id === undefined) {
+      throw new YatlError(
+        'The provided row object does not exist in the current dataset.',
+        'Ensure you are passing a reference from the active data array.',
+      );
     }
-    return metadata.id;
+    return id;
   }
 
   public getRowIndex(row: T) {
-    const metadata = this.rowMetadata.get(row);
-    if (!metadata) {
-      throw new Error('The provided row does not exist in the current dataset');
-    }
-    return metadata.index;
+    return this.getRowMetadata(row).index;
   }
 
   public getRowHighlightIndicies(row: T) {
-    const metadata = this.rowMetadata.get(row);
-    if (!metadata) {
-      throw new Error('The provided row does not exist in the current dataset');
-    }
-    return metadata.highlightIndices;
+    return this.getRowMetadata(row).highlightIndices;
   }
 
   // #endregion
@@ -1235,7 +1241,7 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
       .map(column => column.field);
 
     this._filteredData = this.data.filter((row, index) => {
-      const metadata = this.rowMetadata.get(row)!;
+      const metadata = this.getRowMetadata(row);
       metadata.searchScore = 0;
       metadata.highlightIndices = {};
       // Filter takes precedence over search.
@@ -1293,8 +1299,8 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
       return 0;
     }
 
-    const aMetadata = this.rowMetadata.get(a)!;
-    const bMetadata = this.rowMetadata.get(b)!;
+    const aMetadata = this.getRowMetadata(a);
+    const bMetadata = this.getRowMetadata(b);
 
     if (state.sort?.order === 'asc') {
       aValue = aMetadata.sortValues[field];
@@ -1326,8 +1332,8 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
       .sort((a, b) => b.sort!.priority - a.sort!.priority);
 
     this._filteredData = this._filteredData.toSorted((a, b) => {
-      const aMetadata = this.rowMetadata.get(a)!;
-      const bMetadata = this.rowMetadata.get(b)!;
+      const aMetadata = this.getRowMetadata(a);
+      const bMetadata = this.getRowMetadata(b);
 
       // Try to sort by search score if we're using scoring and there is a query.
       if (this.scoredSearch && this.queryTokens) {
@@ -1354,12 +1360,12 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
 
   // #region Utilities
 
-  private createMetadata() {
+  private rebuildMetadata() {
     this.idToRowMap = new Map();
     const rankMaps = new Map<string, Map<unknown, number>>();
     // TODO: We only need rank maps for sortable columns
     // but the user could enable sorting later. It's easiest
-    // to just compute them all know regardless.
+    // to just compute them all now regardless.
     for (const column of this.columns) {
       // Collect all raw values for this column
       const rawValues = this.data.map(row => {
@@ -1370,17 +1376,15 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
       rankMaps.set(column.field, createRankMap(rawValues));
     }
 
-    for (let index = 0; index < this.data.length; ++index) {
-      const row = this.data[index];
+    this._data.forEach((row, index) => {
       let rowId = this._rowIdCallback(row, index);
-      // If the user screws
       if (rowId == null || this.idToRowMap.has(rowId)) {
         warnInvalidIdFunction(index, rowId, row);
         rowId = `__yatl_fallback_id_${index}`;
       }
 
       const metadata =
-        this.rowMetadata.get(row) ??
+        this.rowMetadata.get(rowId) ??
         ({
           id: rowId,
           index: index,
@@ -1392,8 +1396,11 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
           pendingTransactions: new Map(),
         } as RowMetadata);
 
+      this.rowToIdMap.set(row, rowId);
       this.idToRowMap.set(rowId, row);
-      this.rowMetadata.set(row, metadata);
+      this.rowMetadata.set(rowId, metadata);
+
+      metadata.index = index;
 
       for (const column of this.columns) {
         const value = getNestedValue(row, column.field);
@@ -1413,13 +1420,13 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
           );
         }
       }
-    }
+    });
   }
 
   private updateRowData(row: T, data: object) {
     Object.assign(row, data);
     // TODO: Make this more efficient.
-    this.createMetadata();
+    this.rebuildMetadata();
     this.requestUpdate('data');
   }
 
@@ -1458,8 +1465,8 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
   }
 
   private getRowMetadata(row: T | RowId) {
-    row = this.getRowOrThrow(row);
-    const metadata = this.rowMetadata.get(row);
+    const id = isRowIdType(row) ? row : this.getRowId(row);
+    const metadata = this.rowMetadata.get(id);
     if (!metadata) {
       throw new YatlError(
         'The provided row object does not exist in the current dataset',
@@ -1476,12 +1483,13 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
   private getTransactionRecords(transactionId?: string) {
     const records: YatlCommitRecord<T>[] = [];
     for (const rowId of this.editedRows) {
-      const row = this.getRow(rowId)!;
-      const metadata = this.getRowMetadata(row);
-      const edits = metadata.pendingEdits;
-      if (edits.size === 0) {
+      const row = this.getRow(rowId);
+      const metadata = this.rowMetadata.get(rowId);
+      if (!row || !metadata || metadata.pendingEdits.size === 0) {
         continue;
       }
+
+      const edits = metadata.pendingEdits;
 
       const changes: Partial<T> = {};
       const changedFields = [];

--- a/packages/yatl/src/table-controller/table-controller.ts
+++ b/packages/yatl/src/table-controller/table-controller.ts
@@ -18,17 +18,20 @@ import type {
   TableState,
   TokenizerCallback,
   UnspecifiedRecord,
+  YatlCommitRecord,
+  YatlCommitTransaction,
   YatlTableControllerApi,
 } from '../types';
 
 import {
   createState,
+  getColumnStateChanges,
   getNestedValue,
   isDisplayColumn,
   isRowIdType,
   isRowSelectionMethod,
+  setNestedValue,
   whitespaceTokenizer,
-  getColumnStateChanges,
 } from '../utils';
 
 import { createRankMap } from './utils';
@@ -45,6 +48,7 @@ import {
   YatlTableStateChangeEvent,
   YatlTableViewChangeEvent,
 } from '../events';
+import { throwRowNotFound, YatlError } from '../utils/errors';
 import { TypedEventTarget } from '../utils/typed-event-target';
 
 // #region Constants
@@ -123,6 +127,10 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
   private idToRowMap = new Map<RowId, T>();
   // List of tokens created from the current query
   private queryTokens: QueryToken[] | null = null;
+  // List of rows with pending edits. Just for quick lookup
+  private editedRows = new Set<RowId>();
+  // Transactions that have been started but not finished
+  private pendingTransactions = new Map<string, YatlCommitRecord<T>[]>();
 
   // #endregion
 
@@ -744,6 +752,124 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
     return new Blob([csvContent], { type: 'text/csv;charset=utf-8,' });
   }
 
+  public setPendingValue(
+    row: T | RowId,
+    field: NestedKeyOf<T>,
+    value: unknown,
+  ) {
+    row = this.getRowOrThrow(row);
+    const currentValue = getNestedValue(row, field);
+    const metadata = this.getRowMetadata(row);
+    if (value === currentValue) {
+      metadata.pendingEdits.delete(field);
+      if (metadata.pendingEdits.size === 0) {
+        this.editedRows.delete(metadata.id);
+      }
+    } else {
+      metadata.pendingEdits.set(field, value);
+      this.editedRows.add(metadata.id);
+    }
+  }
+
+  /**
+   * Gets the latest value for the cell at the given row and field.
+   * This will prioritize live edits first, pending commit transactions second
+   * and finally the actual value in the row data.
+   * @param row
+   * @param field
+   * @returns
+   */
+  public getLatestValue(row: T | RowId, field: NestedKeyOf<T>) {
+    row = this.getRowOrThrow(row);
+    const metadata = this.getRowMetadata(row);
+
+    let value = metadata.pendingEdits.get(field);
+    if (value !== undefined) {
+      return value;
+    }
+
+    value = metadata.pendingTransactions.get(field)?.value;
+    if (value !== undefined) {
+      return value;
+    }
+
+    return getNestedValue(row, field);
+  }
+
+  public getCellStatus(row: T | RowId, field: NestedKeyOf<T>) {
+    const metadata = this.rowMetadata.get(this.getRowOrThrow(row));
+    if (!metadata) return 'clean';
+
+    if (metadata.pendingTransactions.has(field as string)) {
+      return 'saving';
+    }
+
+    if (metadata.pendingEdits.has(field as string)) {
+      return 'dirty';
+    }
+
+    return 'clean';
+  }
+
+  public getPendingChanges() {
+    return this.getTransactionRecords();
+  }
+
+  public createCommitTransaction(): YatlCommitTransaction | null {
+    const transactionId = crypto.randomUUID();
+    const records = this.getTransactionRecords(transactionId);
+    if (records.length === 0) return null;
+
+    this.pendingTransactions.set(transactionId, records);
+    // Need to tell the table to update the status
+    this.requestUpdate();
+    return { id: transactionId, records };
+  }
+
+  public resolveTransaction(id: string) {
+    this.closeTransaction(id, 'resolve');
+  }
+
+  public rejectTransaction(id: string) {
+    this.closeTransaction(id, 'reject');
+  }
+
+  public discardTransaction(id: string) {
+    this.closeTransaction(id, 'discard');
+  }
+
+  public commitChanges(row: T | RowId, field: NestedKeyOf<T>, update = true) {
+    row = this.getRowOrThrow(row);
+    const metadata = this.getRowMetadata(row);
+    const currentValue = metadata.pendingEdits.get(field);
+    if (currentValue !== undefined) {
+      setNestedValue(row, field, currentValue);
+      this.editedRows.delete(metadata.id);
+      if (update) {
+        this.requestUpdate('data');
+      }
+    }
+  }
+
+  public async commitAllChanges() {
+    for (const rowId of this.editedRows) {
+      const metadata = this.getRowMetadata(rowId);
+      for (const field of metadata.pendingEdits.keys()) {
+        this.commitChanges(rowId, field as NestedKeyOf<T>, false);
+      }
+    }
+    this.requestUpdate('data');
+  }
+
+  public async revertPendingChanges() {
+    for (const rowId of this.editedRows) {
+      const row = this.getRow(rowId)!;
+      const metadata = this.getRowMetadata(row);
+      metadata.pendingEdits.clear();
+    }
+    this.requestUpdate();
+  }
+
   /**
    * Gets the row associated with the provided ID.
    * @param id - The ID of the row to get
@@ -1219,8 +1345,6 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
 
   private createMetadata() {
     this.idToRowMap = new Map();
-    this.rowMetadata = new WeakMap();
-
     const rankMaps = new Map<string, Map<unknown, number>>();
     // TODO: We only need rank maps for sortable columns
     // but the user could enable sorting later. It's easiest
@@ -1235,8 +1359,8 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
       rankMaps.set(column.field, createRankMap(rawValues));
     }
 
-    let index = 0;
-    for (const row of this.data) {
+    for (let index = 0; index < this.data.length; ++index) {
+      const row = this.data[index];
       let rowId = this._rowIdCallback(row, index);
       // If the user screws
       if (rowId == null || this.idToRowMap.has(rowId)) {
@@ -1244,16 +1368,20 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
         rowId = `__yatl_fallback_id_${index}`;
       }
 
+      const metadata =
+        this.rowMetadata.get(row) ??
+        ({
+          id: rowId,
+          index: index,
+          searchTokens: {},
+          searchValues: {},
+          sortValues: {},
+          selected: false,
+          pendingEdits: new Map(),
+          pendingTransactions: new Map(),
+        } as RowMetadata);
+
       this.idToRowMap.set(rowId, row);
-      // Add the index
-      const metadata: RowMetadata = {
-        id: rowId,
-        index: index++,
-        searchTokens: {},
-        searchValues: {},
-        sortValues: {},
-        selected: false,
-      };
       this.rowMetadata.set(row, metadata);
 
       for (const column of this.columns) {
@@ -1305,6 +1433,103 @@ export class YatlTableController<T extends object = UnspecifiedRecord>
     this.saveTimer = window.setTimeout(() => {
       this.saveStateToStorage();
     }, STATE_SAVE_DEBOUNCE);
+  }
+
+  private getRowOrThrow(row: T | RowId) {
+    if (isRowIdType(row)) {
+      row = this.getRow(row)!;
+      if (!row) {
+        throwRowNotFound(row);
+      }
+      return row;
+    }
+    return row;
+  }
+
+  private getRowMetadata(row: T | RowId) {
+    row = this.getRowOrThrow(row);
+    const metadata = this.rowMetadata.get(row);
+    if (!metadata) {
+      throw new YatlError(
+        'The provided row object does not exist in the current dataset',
+      );
+    }
+    return metadata;
+  }
+
+  /**
+   * Gets the list of transaction records from the current edits.
+   * @param transactionId If provied, moves the values from pending edits to pending transactions
+   * @returns
+   */
+  private getTransactionRecords(transactionId?: string) {
+    const records: YatlCommitRecord<T>[] = [];
+    for (const rowId of this.editedRows) {
+      const row = this.getRow(rowId)!;
+      const metadata = this.getRowMetadata(row);
+      const edits = metadata.pendingEdits;
+      if (edits.size === 0) {
+        continue;
+      }
+
+      const changes: Partial<T> = {};
+      const changedFields = [];
+      const mergedRow = structuredClone(row);
+      for (const [field, value] of edits.entries()) {
+        changedFields.push(field as NestedKeyOf<T>);
+        setNestedValue(changes, field, value);
+        setNestedValue(mergedRow, field, value);
+      }
+
+      records.push({
+        rowId: rowId,
+        changedFields: changedFields,
+        originalRow: row,
+        changes: changes,
+        mergedRow: mergedRow,
+      });
+
+      if (transactionId) {
+        for (const [key, value] of edits.entries()) {
+          metadata.pendingTransactions.set(key, { id: transactionId, value });
+        }
+        edits.clear();
+      }
+    }
+    return records;
+  }
+
+  private closeTransaction(
+    id: string,
+    action: 'resolve' | 'reject' | 'discard',
+  ) {
+    const records = this.pendingTransactions.get(id);
+    if (!records) {
+      throw new YatlError(
+        `Attempting to commit non-existent transaction ${id}`,
+      );
+    }
+
+    for (const record of records) {
+      const metadata = this.getRowMetadata(record.rowId);
+      for (const field of record.changedFields) {
+        const pendingData = metadata.pendingTransactions.get(field);
+        if (pendingData?.id === id) {
+          // If the data in pending transactions is still for this transactions
+          if (action === 'reject' && !metadata.pendingEdits.has(field)) {
+            // If the user is rejecting the transaction we want to keep the data
+            metadata.pendingEdits.set(field, pendingData.value);
+            this.editedRows.add(record.rowId);
+          }
+          metadata.pendingTransactions.delete(field);
+        }
+      }
+      if (action === 'resolve') {
+        this.updateRow(record.rowId, record.changes);
+      }
+    }
+    this.pendingTransactions.delete(id);
+    this.requestUpdate();
   }
 
   // #endregion
@@ -1439,6 +1664,8 @@ interface RowMetadata {
   sortValues: Record<string, number | null>;
   highlightIndices?: Record<string, [number, number][]>;
   selected: boolean;
+  pendingEdits: Map<string, unknown>;
+  pendingTransactions: Map<string, { id: string; value: unknown }>;
 }
 
 interface SearchResult {

--- a/packages/yatl/src/table/table.styles.ts
+++ b/packages/yatl/src/table/table.styles.ts
@@ -123,6 +123,7 @@ export default css`
     }
 
     .cell {
+      position: relative;
       align-items: center;
       padding: var(--table-cell-padding);
     }
@@ -131,18 +132,53 @@ export default css`
       justify-content: flex-end;
     }
 
-    .cell.is-editing {
-      padding: 0;
+    [part='status-indicator'] {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 0;
+      height: 0;
+      border-top: 8px solid transparent;
+      border-right: 8px solid transparent;
+      pointer-events: none;
     }
 
-    .cell.is-editing > * {
-      width: 100%;
-      height: 100%;
+    .cell.is-dirty [part='status-indicator'] {
+      border-top-color: var(--yatl-color-brand);
+      border-right-color: transparent;
+    }
+
+    .cell.is-saving {
+      opacity: 0.6;
+    }
+
+    .cell.is-saving [part='status-indicator'] {
+      border-top-color: var(--yatl-color-);
+      animation: pulse 1.5s infinite alternate ease-in-out;
+    }
+
+    .cell.is-editing {
+      padding: 0;
       box-sizing: border-box;
-      outline: none;
-      padding: var(--yatl-spacing-m);
+      --yatl-input-border-width: 0px;
+      --yatl-input-outline-width: 0px;
       border: 1px solid var(--yatl-color-brand);
       border-radius: var(--yatl-radius-xs);
+
+      & > * {
+        width: 100%;
+        height: 100%;
+      }
+
+      input,
+      select {
+        outline: none;
+        padding: var(--yatl-spacing-m);
+      }
+    }
+
+    :host([edit-mode='bulk']) .cell.is-editing {
+      border: none;
     }
 
     .table.resizing * {
@@ -426,6 +462,15 @@ export default css`
 
     .cell {
       border: 1px solid black;
+    }
+  }
+
+  @keyframes pulse {
+    0% {
+      opacity: 0.4;
+    }
+    100% {
+      opacity: 1;
     }
   }
 `;

--- a/packages/yatl/src/table/table.ts
+++ b/packages/yatl/src/table/table.ts
@@ -1284,8 +1284,33 @@ export class YatlTable<T extends object = UnspecifiedRecord>
 
   private dispatchTransaction() {
     const transaction = this.controller.createCommitTransaction();
-    if (transaction) {
-      this.dispatchEvent(new YatlTableCommitRequest(transaction));
+    if (!transaction) {
+      return;
+    }
+
+    let isHandled = false;
+    const event = new YatlTableCommitRequest(transaction, async promise => {
+      isHandled = true;
+
+      if (promise instanceof Promise) {
+        try {
+          promise = await promise;
+        } catch {
+          promise = false;
+        }
+      }
+
+      if (promise) {
+        this.controller.resolveTransaction(transaction.id);
+      } else {
+        this.controller.rejectTransaction(transaction.id);
+      }
+    });
+    this.dispatchEvent(event);
+
+    if (!isHandled) {
+      // User didn't respond to the event so just reject the edits.
+      this.controller.rejectTransaction(transaction.id);
     }
   }
 

--- a/packages/yatl/src/table/table.ts
+++ b/packages/yatl/src/table/table.ts
@@ -12,23 +12,23 @@ import type {
   TableState,
   UnspecifiedRecord,
   YatlTableApi,
+  YatlTableCommitStrategy,
 } from '../types';
 
 import {
   getColumnStateChanges,
   getNestedValue,
   isDisplayColumn,
-  setNestedValue,
 } from '../utils';
 
 import { highlightText, toHumanReadable } from './utils';
 
 import {
-  YatlCellEditEvent,
   YatlColumnReorderRequest,
   YatlColumnSortRequest,
   YatlRowClickEvent,
   YatlRowSelectRequest,
+  YatlTableCommitRequest,
   YatlTableControllerEvent,
 } from '../events';
 
@@ -58,7 +58,6 @@ import styles from './table.styles';
  * @element yatl-table
  * @summary A high-performance grid engine for rugged environments.
  *
- * @fires yatl-cell-edit - Fired after a cell value has been edited.
  * @fires yatl-row-click - Fired when a user clicks a row.
  * @fires yatl-row-select-request - Fired before the row selection changes. Cancellable
  * @fires yatl-row-select - Fired when the row selection changes.
@@ -68,6 +67,7 @@ import styles from './table.styles';
  * @fires yatl-column-resize - Fired after a column has been resized by the user.
  * @fires yatl-column-reorder-request - Fired when the user drops a column into a new position. Cancellable.
  * @fires yatl-column-reorder - Fired after the column order changes.
+ * @fires yatl-table-commit-request -
  * @fires yatl-table-search - Fired when the search query is updated.
  * @fires yatl-table-view-change - Fired when the visible slice of data changes due to sorting, filtering, or data updates. Payload contains the processed rows.
  * @fires yatl-table-state-change - Fired when any persistable state (width, order, sort, query) changes. Used for syncing with local storage.
@@ -111,10 +111,9 @@ export class YatlTable<T extends object = UnspecifiedRecord>
   private useYatlUi = false;
 
   @state()
-  private editingState: {
-    id: RowId;
+  private currentEditCell: {
+    rowId: RowId;
     field: NestedKeyOf<T>;
-    originalValue: unknown;
   } | null = null;
 
   private _controller = new YatlTableController<T>(this);
@@ -275,6 +274,10 @@ export class YatlTable<T extends object = UnspecifiedRecord>
     this.controller.searchTokenizer = tokenizer;
   }
 
+  /** @attr commit-strategy */
+  @property({ type: String, attribute: 'commit-strategy', reflect: true })
+  public commitStrategy: YatlTableCommitStrategy = 'immediate';
+
   /** @attr row-selection-method */
   public get rowSelectionMethod() {
     return this.controller.rowSelectionMethod;
@@ -325,6 +328,9 @@ export class YatlTable<T extends object = UnspecifiedRecord>
   }
 
   @property({ type: Boolean, reflect: true })
+  public readonly = false;
+
+  @property({ type: Boolean, reflect: true })
   public striped = false;
 
   @property({ type: Boolean })
@@ -347,10 +353,6 @@ export class YatlTable<T extends object = UnspecifiedRecord>
   /** @attr hide-footer */
   @property({ type: Boolean, attribute: 'hide-footer' })
   public hideFooter = false;
-
-  /** @attr disable-editing */
-  @property({ type: Boolean, attribute: 'disable-editing' })
-  public disableEditing = false;
 
   /**
    * @default "-"
@@ -873,7 +875,14 @@ export class YatlTable<T extends object = UnspecifiedRecord>
   }
 
   protected renderCell(column: DisplayColumnOptions<T>, row: T) {
-    let value = getNestedValue(row, column.field);
+    const status = this.controller.getCellStatus(row, column.field);
+    // Try to use the value from any pending edits if they exist.
+    let value = this.controller.getLatestValue(row, column.field);
+    if (value === undefined) {
+      // If not, fallback to the actual value.
+      value = getNestedValue(row, column.field);
+    }
+
     // Get the user parts from the raw value
     // before we call the value formatter.
     let userParts = column.cellParts?.call(this, value, column.field, row);
@@ -885,16 +894,18 @@ export class YatlTable<T extends object = UnspecifiedRecord>
     const classes = {
       cell: true,
       'is-number': inputType === 'number',
+      'is-dirty': status === 'dirty',
+      'is-saving': status === 'saving',
     };
 
-    const rowId = this.controller.getRowId(row);
     const field = column.field;
+    const rowId = this.controller.getRowId(row);
+
     if (
-      column.editor &&
-      !this.disableEditing &&
-      this.editingState &&
-      this.editingState.id === rowId &&
-      this.editingState.field === field
+      !this.readonly &&
+      this.currentEditCell &&
+      rowId === this.currentEditCell.rowId &&
+      field === this.currentEditCell.field
     ) {
       return this.renderCellWrapper(html`
         <div
@@ -903,7 +914,7 @@ export class YatlTable<T extends object = UnspecifiedRecord>
           class=${classMap({ ...classes, 'is-editing': true })}
           data-field=${column.field}
         >
-          ${column.editor.render(value, field, row, this.controller)}
+          ${column.editor!.render(value, field, row, this.controller)}
         </div>
       `);
     }
@@ -925,6 +936,10 @@ export class YatlTable<T extends object = UnspecifiedRecord>
         <span class="truncate">
           ${this.renderCellContents(value, column, row)}
         </span>
+
+        ${status !== 'clean'
+          ? html`<div part="status-indicator"></div>`
+          : nothing}
       </div>
     `);
   }
@@ -980,6 +995,7 @@ export class YatlTable<T extends object = UnspecifiedRecord>
       'row-odd': renderIndex % 2 !== 0,
     };
     const rowIndex = renderIndex + 1;
+    const rowId = this.controller.getRowId(row);
 
     return html`
       <div
@@ -988,6 +1004,7 @@ export class YatlTable<T extends object = UnspecifiedRecord>
         aria-selected=${selected ? 'true' : 'false'}
         part=${'row ' + userParts}
         class=${classMap(classes)}
+        data-row-id=${rowId}
       >
         ${this.renderRowNumberCell(rowIndex)}
         ${this.renderRowSelectorCell(row, selected)}
@@ -1265,39 +1282,10 @@ export class YatlTable<T extends object = UnspecifiedRecord>
     }
   }
 
-  private async saveEdits() {
-    if (!this.editingState) {
-      return;
-    }
-
-    const { id: rowId, field, originalValue } = this.editingState;
-    const column = this.getDisplayColumn(field);
-    const row = this.getRow(rowId);
-    if (!column?.editor || !row) {
-      return;
-    }
-
-    let value;
-    const result = column.editor.save(
-      originalValue,
-      field,
-      row,
-      this.controller,
-    );
-
-    if (result instanceof Promise) {
-      value = await result;
-    } else {
-      value = result;
-    }
-
-    if (value !== undefined) {
-      const updateData = {};
-      setNestedValue(updateData, field, value);
-      this.updateRow(rowId, updateData as Partial<T>);
-      this.dispatchEvent(
-        new YatlCellEditEvent(row, rowId, field, originalValue, value),
-      );
+  private dispatchTransaction() {
+    const transaction = this.controller.createCommitTransaction();
+    if (transaction) {
+      this.dispatchEvent(new YatlTableCommitRequest(transaction));
     }
   }
 
@@ -1342,7 +1330,21 @@ export class YatlTable<T extends object = UnspecifiedRecord>
     field: NestedKeyOf<T>,
   ) => {
     // Ignore events if the user is highlighting text
-    if (this.editingState || window.getSelection()?.toString()) {
+    if (window.getSelection()?.toString()) {
+      return;
+    }
+
+    const col = this.getDisplayColumn(field);
+    const rowId = this.controller.getRowId(row);
+    if (
+      this.commitStrategy !== 'immediate' &&
+      rowId === this.currentEditCell?.rowId &&
+      field !== this.currentEditCell.field &&
+      col?.editor
+    ) {
+      // We are currently editing this row and we are bulk editing
+      // so just start editing the new cell they clicked.
+      this.currentEditCell = { rowId, field };
       return;
     }
 
@@ -1356,7 +1358,6 @@ export class YatlTable<T extends object = UnspecifiedRecord>
       return;
     }
 
-    const rowId = this.controller.getRowId(row);
     const rowIndex = this.controller.getRowIndex(row);
     this.dispatchEvent(
       new YatlRowClickEvent(row, rowId, rowIndex, field, event),
@@ -1364,40 +1365,39 @@ export class YatlTable<T extends object = UnspecifiedRecord>
   };
 
   private handleCellDoubleClick(row: T, field: NestedKeyOf<T>) {
-    const column = this.getDisplayColumn(field);
-    if (!column || !column.editor || !column.editor.canEdit(field, row)) {
+    if (this.readonly) {
       return;
     }
 
-    column.editor.reset();
-    const value = getNestedValue(row, field);
-    this.editingState = {
-      id: this.controller.getRowId(row),
-      field: field,
-      originalValue: value,
-    };
+    const rowId = this.controller.getRowId(row);
+    this.currentEditCell = { rowId, field };
   }
 
   private handleCellInputKeypress(event: KeyboardEvent) {
-    if (!this.editingState) {
+    if (!this.currentEditCell) {
       return;
     }
 
-    if (event.key === 'Escape') {
-      this.editingState = null;
-    } else if (event.key === 'Enter') {
-      this.saveEdits();
-      this.editingState = null;
-    } else if (event.key === 'Tab') {
-      this.saveEdits();
+    const { rowId, field } = this.currentEditCell;
+    const row = this.getRow(rowId)!;
 
-      const { id: rowId } = this.editingState;
-      const row = this.getRow(rowId)!;
+    if (event.key === 'Escape') {
+      this.currentEditCell = null;
+      this.controller.revertPendingChanges();
+    } else if (event.key === 'Enter') {
+      this.dispatchTransaction();
+      this.currentEditCell = null;
+    } else if (event.key === 'Tab') {
+      this.currentEditCell = null;
+      if (this.commitStrategy === 'immediate') {
+        this.dispatchTransaction();
+      }
 
       // Try to find the next editable field in this row.
-      let nextColumn = this.getNextEditableField(row, this.editingState.field);
+      let nextColumn = this.getNextEditableField(row, field);
       if (nextColumn) {
-        return this.handleCellDoubleClick(row, nextColumn);
+        this.handleCellDoubleClick(row, nextColumn);
+        return;
       }
 
       let rowIndex = this.filteredData.indexOf(row);
@@ -1417,21 +1417,41 @@ export class YatlTable<T extends object = UnspecifiedRecord>
       if (!nextColumn) {
         return;
       }
+
+      if (this.commitStrategy === 'row') {
+        this.dispatchTransaction();
+      }
+
       this.handleCellDoubleClick(nextRow, nextColumn);
       event.preventDefault();
     }
   }
 
   private handleMouseDown(event: Event) {
-    const containsEditing = event
+    if (!this.currentEditCell) {
+      return;
+    }
+
+    const isWithinEdit = event
       .composedPath()
       .filter(e => e instanceof HTMLElement)
-      .some(e => e.classList.contains('is-editing'));
+      .some(e => {
+        if (this.commitStrategy === 'immediate') {
+          // Commit and end edit when clicking out of the cell
+          return e.classList.contains('is-editing');
+        } else {
+          // Commit and end edit when clicking out of the row
+          // This is intentionally a loose equality check.
+          return e.dataset.rowId == this.currentEditCell?.rowId;
+        }
+      });
 
-    if (this.editingState && !containsEditing) {
-      console.log('saving');
-      this.saveEdits();
-      this.editingState = null;
+    if (!isWithinEdit) {
+      if (this.commitStrategy !== 'batch') {
+        // Never commit with batch editing. Thats the user's job.
+        this.dispatchTransaction();
+      }
+      this.currentEditCell = null;
     }
   }
 

--- a/packages/yatl/src/table/table.ts
+++ b/packages/yatl/src/table/table.ts
@@ -905,7 +905,8 @@ export class YatlTable<T extends object = UnspecifiedRecord>
       !this.readonly &&
       this.currentEditCell &&
       rowId === this.currentEditCell.rowId &&
-      field === this.currentEditCell.field
+      field === this.currentEditCell.field &&
+      this.controller.isCellEditable(row, field)
     ) {
       return this.renderCellWrapper(html`
         <div

--- a/packages/yatl/src/table/table.ts
+++ b/packages/yatl/src/table/table.ts
@@ -1422,7 +1422,18 @@ export class YatlTable<T extends object = UnspecifiedRecord>
     if (event.key === 'Escape') {
       this.currentEditCell = null;
       this.controller.revertPendingChanges();
-    } else if (event.key === 'Enter') {
+      event.stopPropagation();
+      event.preventDefault();
+      return;
+    }
+
+    if (event.key !== 'Enter' && event.key !== 'Tab') {
+      return;
+    }
+
+    this.editor?.blur();
+
+    if (event.key === 'Enter') {
       this.dispatchTransaction();
       this.currentEditCell = null;
     } else if (event.key === 'Tab') {

--- a/packages/yatl/src/table/table.ts
+++ b/packages/yatl/src/table/table.ts
@@ -13,6 +13,7 @@ import type {
   UnspecifiedRecord,
   YatlTableApi,
   YatlTableCommitStrategy,
+  YatlTableEditTrigger,
 } from '../types';
 
 import {
@@ -275,8 +276,17 @@ export class YatlTable<T extends object = UnspecifiedRecord>
   }
 
   /** @attr commit-strategy */
-  @property({ type: String, attribute: 'commit-strategy', reflect: true })
+  @property({ type: String, attribute: 'commit-strategy' })
   public commitStrategy: YatlTableCommitStrategy = 'immediate';
+
+  /**
+   * Controls how a user initiates cell editing within the table.
+   * @default 'dblclick'
+   * @see {@link YatlTableEditTrigger} for available options.
+   * @attr edit-trigger
+   */
+  @property({ type: String, attribute: 'edit-trigger' })
+  public editTrigger: YatlTableEditTrigger = 'dblclick';
 
   /** @attr row-selection-method */
   public get rowSelectionMethod() {
@@ -1265,6 +1275,19 @@ export class YatlTable<T extends object = UnspecifiedRecord>
     return 'text';
   }
 
+  private beginCellEdit(row: T, field: NestedKeyOf<T>) {
+    if (
+      this.readonly ||
+      this.editTrigger === 'none' ||
+      !this.controller.isCellEditable(row, field)
+    ) {
+      return;
+    }
+
+    const rowId = this.controller.getRowId(row);
+    this.currentEditCell = { rowId, field };
+  }
+
   private getNextEditableField(row: T, currentField?: NestedKeyOf<T>) {
     let index = 0;
     if (currentField) {
@@ -1360,18 +1383,8 @@ export class YatlTable<T extends object = UnspecifiedRecord>
       return;
     }
 
-    const col = this.getDisplayColumn(field);
-    const rowId = this.controller.getRowId(row);
-    if (
-      this.commitStrategy !== 'immediate' &&
-      rowId === this.currentEditCell?.rowId &&
-      field !== this.currentEditCell.field &&
-      col?.editor
-    ) {
-      // We are currently editing this row and we are bulk editing
-      // so just start editing the new cell they clicked.
-      this.currentEditCell = { rowId, field };
-      return;
+    if (this.editTrigger === 'click') {
+      this.beginCellEdit(row, field);
     }
 
     // Ignore links and buttons
@@ -1384,6 +1397,7 @@ export class YatlTable<T extends object = UnspecifiedRecord>
       return;
     }
 
+    const rowId = this.controller.getRowId(row);
     const rowIndex = this.controller.getRowIndex(row);
     this.dispatchEvent(
       new YatlRowClickEvent(row, rowId, rowIndex, field, event),
@@ -1391,12 +1405,10 @@ export class YatlTable<T extends object = UnspecifiedRecord>
   };
 
   private handleCellDoubleClick(row: T, field: NestedKeyOf<T>) {
-    if (this.readonly) {
+    if (this.editTrigger !== 'dblclick') {
       return;
     }
-
-    const rowId = this.controller.getRowId(row);
-    this.currentEditCell = { rowId, field };
+    this.beginCellEdit(row, field);
   }
 
   private handleCellInputKeypress(event: KeyboardEvent) {
@@ -1422,7 +1434,7 @@ export class YatlTable<T extends object = UnspecifiedRecord>
       // Try to find the next editable field in this row.
       let nextColumn = this.getNextEditableField(row, field);
       if (nextColumn) {
-        this.handleCellDoubleClick(row, nextColumn);
+        this.beginCellEdit(row, nextColumn);
         return;
       }
 
@@ -1448,7 +1460,7 @@ export class YatlTable<T extends object = UnspecifiedRecord>
         this.dispatchTransaction();
       }
 
-      this.handleCellDoubleClick(nextRow, nextColumn);
+      this.beginCellEdit(nextRow, nextColumn);
       event.preventDefault();
     }
   }

--- a/packages/yatl/src/types/columns.ts
+++ b/packages/yatl/src/types/columns.ts
@@ -59,12 +59,6 @@ export type SortValueCallback = (value: unknown) => Compareable;
  */
 export interface CellEditor<T extends object = UnspecifiedRecord> {
   /**
-   * Reset the state of the editor before a new cell uses it
-   * @returns
-   */
-  reset: () => void;
-
-  /**
    * A function to determine if editing should be allowed for the given row.
    */
   canEdit: (field: NestedKeyOf<T>, row: T) => boolean;
@@ -83,23 +77,6 @@ export interface CellEditor<T extends object = UnspecifiedRecord> {
     row: T,
     controller: YatlTableController<T>,
   ) => unknown;
-
-  /**
-   * A method for saving the data. If it's async,
-   * the promise will be awaited before closing the edit.
-   * @param originalValue - The value before editing
-   * @param field The field that is being edited
-   * @param row The row that is being edited
-   * @param controller The table's controller
-   * @returns The new value or a promise to the new value.
-   * If undefined is returned, the edit is cancelled
-   */
-  save: (
-    originalValue: unknown,
-    field: NestedKeyOf<T>,
-    row: T,
-    controller: YatlTableController<T>,
-  ) => MaybePromise<unknown | undefined>;
 }
 
 /**

--- a/packages/yatl/src/types/table.ts
+++ b/packages/yatl/src/types/table.ts
@@ -9,20 +9,28 @@ export type RowIdCallback<T extends object = UnspecifiedRecord> = (
 ) => RowId;
 
 /**
- * The method used for selecting rows.
- * * single - Only a single row can be selected at a time
- * * multi - Multiple rows can be selected at a time
- * * null - Disable row selection
- */
-export type RowSelectionMethod = 'single' | 'multi';
-
-/**
  * The current editing mode of the table
  * * immediate - Data is commited to the table as soon as cell editing ends
  * * row - Data is commited to the table when editing leaves the current row
  * * batch - Data is not automatically commited. User must manually commit changes
  */
 export type YatlTableCommitStrategy = 'immediate' | 'row' | 'batch';
+
+/**
+ * The method used to start cell editing
+ * * click - A single click on an editable cell shows the editor
+ * * dblclick - Double clicking on an editable cell shows the editor
+ * * none - In-cell editing is completely disabled
+ */
+export type YatlTableEditTrigger = 'click' | 'dblclick' | 'none';
+
+/**
+ * The method used for selecting rows.
+ * * single - Only a single row can be selected at a time
+ * * multi - Multiple rows can be selected at a time
+ * * null - Disable row selection
+ */
+export type RowSelectionMethod = 'single' | 'multi';
 
 /**
  * A commit record describing the changes to a single row.
@@ -342,6 +350,11 @@ export interface YatlTableApi<T extends object = UnspecifiedRecord>
    * The message displayed when `data` exists but the current search/filter results in zero visible rows.
    */
   noResultsMessage: string;
+
+  /**
+   *
+   */
+  editTrigger: YatlTableEditTrigger;
 
   /**
    * A callback function to conditionally apply CSS parts to table rows.

--- a/packages/yatl/src/types/table.ts
+++ b/packages/yatl/src/types/table.ts
@@ -1,6 +1,6 @@
 import { YatlTableController } from '../table-controller/table-controller';
 import { ColumnOptions, ColumnState, RestorableColumnState } from './columns';
-import { RowId, UnspecifiedRecord } from './common';
+import { NestedKeyOf, RowId, UnspecifiedRecord } from './common';
 import { FilterCallback, Filters, TokenizerCallback } from './filters';
 
 export type RowIdCallback<T extends object = UnspecifiedRecord> = (
@@ -15,6 +15,47 @@ export type RowIdCallback<T extends object = UnspecifiedRecord> = (
  * * null - Disable row selection
  */
 export type RowSelectionMethod = 'single' | 'multi';
+
+/**
+ * The current editing mode of the table
+ * * immediate - Data is commited to the table as soon as cell editing ends
+ * * row - Data is commited to the table when editing leaves the current row
+ * * batch - Data is not automatically commited. User must manually commit changes
+ */
+export type YatlTableCommitStrategy = 'immediate' | 'row' | 'batch';
+
+/**
+ * A commit record describing the changes to a single row.
+ */
+export interface YatlCommitRecord<T extends object = UnspecifiedRecord> {
+  /** The unique identifier for the row */
+  rowId: RowId;
+
+  /**
+   * List of fields that changed during this transactions
+   */
+  changedFields: NestedKeyOf<T>[];
+
+  /**
+   * A read-only reference to the original, unedited row data.
+   */
+  originalRow: T;
+
+  /**
+   * A partial object of only the fields that changed and their new, parsed values.
+   */
+  changes: Partial<T>;
+
+  /**
+   * A new row object containing the originalRow with the 'changes' deeply applied.
+   */
+  mergedRow: T;
+}
+
+export interface YatlCommitTransaction<T extends object = UnspecifiedRecord> {
+  id: string;
+  records: YatlCommitRecord<T>[];
+}
 
 /**
  * Callback for conditionally adding classes to a row
@@ -240,6 +281,11 @@ export interface YatlTableApi<T extends object = UnspecifiedRecord>
   controller: YatlTableController<T>;
 
   /**
+   * When set, editing is completely disabled.
+   */
+  readonly: boolean;
+
+  /**
    * Enables visual row striping
    */
   striped: boolean;
@@ -281,11 +327,6 @@ export interface YatlTableApi<T extends object = UnspecifiedRecord>
    * The footer content can be customized using the `slot="footer"` element.
    */
   hideFooter: boolean;
-
-  /**
-   * When set, completely disables editing for all columns.
-   */
-  disableEditing: boolean;
 
   /**
    * The string to display in a cell when the data value is `null` or `undefined`.

--- a/packages/yatl/src/utils/errors.ts
+++ b/packages/yatl/src/utils/errors.ts
@@ -1,0 +1,32 @@
+import { RowId } from '../types';
+
+export class YatlError extends Error {
+  constructor(message: string, solution?: string) {
+    if (solution) {
+      message += '\n' + solution;
+    }
+    super(`[yatl-table] ${message}`);
+    this.name = 'YatlError';
+  }
+}
+
+export function throwInvalidRowId(providedId: unknown): never {
+  const isMissing = providedId === null || providedId === undefined;
+
+  const message = isMissing
+    ? `RowID cannot be null or undefined.`
+    : `Expected a string or number for RowID, but received: ${String(
+        providedId,
+      )} (type: ${typeof providedId}).`;
+
+  const solution = `Verify that you are passing the correct identifier and that your 'rowIdCallback' is returning a valid primitive.`;
+
+  throw new YatlError(message, solution);
+}
+
+export function throwRowNotFound(rowId: RowId): never {
+  throw new YatlError(
+    `RowID "${String(rowId)}" does not exist in the current dataset.`,
+    `Ensure the data has been loaded before calling this method, or check your RowID logic.`,
+  );
+}


### PR DESCRIPTION
# Overview
This PR introduces a complete overhaul of the table's editing and commit lifecycle. It shifts the architecture from simple localized edits to a fully managed transaction engine. It also includes some minor tweaks to how the controller manages it's internal state and data.

# Architectural Shifts
Transitioned the internal metadata map from a WeakMap<T, RowMetadata> to a Map<RowId, RowMetadata> (supported by a lightweight reverse-index bridge).

### Why??
Local draft edits and cell UI states now persist across remote data reloads. If a background interval updates the table data, the user's pending edits are preserved instead of being wiped out. This is because we map the metadata to the rowID so as long as the rowID is actually unique (which it better be!) everything persists.

# The New Transaction API
There is a new transaction API for grouping edits into transactions that can be applied, reverted, or discarded altogether.

## The controller
The controller now exposes four core transaction verbs that manage the exact lifecycle of an edit:

### createTransaction()
Locks the targeted cells, generates a unique transaction ID, and packages the pending edits for the consumer.

### resolveTransaction(id)
Called on a successful API save. Applies the edits to the baseline data, unlocks the cells, and clears the UI indicators.

### rejectTransaction(id)
Called on a failed API save. Unlocks the cells but keeps the edits and "dirty" dog-ear markers so the user doesn't lose their work and can try again.

### discardTransaction(id)
Completely aborts the edit, wiping the pending state and reverting the UI back to the original baseline data.

## The table
On top of that, the table component now has some new properties and events to take full advantage of this new API:

### commitStrategy (commit-strategy)
This dictates when commit requests are fired (coming up after this).
* immediate - Fires as soon as a cell edit is complete
* row - Fires when editing leaves the row
* batch - Never fires... that's on you.

### editTrigger (edit-trigger)
This dictates how editing is initiated.
* click - A single click in on an editable cell opens the editor
* dblclick - Double clicking an editable cell opens the editor
* none - I think you know...

### yatl-table-commit-request
An event that fires from the table indicating that a new transaction has been created. This includes a list of pending changes as well as a a respondWith(promise: Promise<boolean>) callback. Consumers can pass their API promise or a true / false boolean to this callback, allowing the table to automatically handle the resolution, rejection, and UI cleanup of the transaction. 

Lastly, there is a new status indicator in the top left corner of the cell to indicate it's status (has edits, is saving, or clean).

